### PR TITLE
use restartCounter to detect proxy modes

### DIFF
--- a/rolemgr.ts
+++ b/rolemgr.ts
@@ -232,38 +232,6 @@ namespace jacdac._rolemgr {
             return buf.hash(32)
         }
 
-        resetToProxy() {
-            this.log(`reset into proxy mode`)
-            settings.writeNumber(JACDAC_PROXY_SETTING, 1)
-            control.reset()
-        }
-
-        checkProxy() {
-            if (!this.running) return
-            const now = control.micros()
-            const self = jacdac.bus.selfDevice
-            const devs = jacdac.bus.devices.filter(
-                d =>
-                    d !== self &&
-                    !!(d.announceflags & ControlAnnounceFlags.IsClient)
-            )
-            if (!devs.length) return // nothing to do here
-
-            //this.log(`check proxy self ${((now / 100000) | 0) / 10}s`)
-            for (const device of devs) {
-                const uptime = device.uptime
-                if (uptime === undefined) {
-                    //this.log(`check proxy ${device.shortId}: no uptime`)
-                    device.sendCtrlCommand(CMD_GET_REG | ControlReg.Uptime)
-                } else {
-                    //this.log(`check proxy ${device.shortId}: ${((uptime / 100000) | 0) / 10}s`)
-                    if (now > uptime) {
-                        this.resetToProxy()
-                    }
-                }
-            }
-        }
-
         bindRoles() {
             if (!this.running) return
             if (jacdac.bus.unattachedClients.length == 0) {

--- a/routing.ts
+++ b/routing.ts
@@ -113,6 +113,10 @@ namespace jacdac {
             }
         }
 
+        get isClient() {
+            return roleManagerServer.running
+        }
+
         queueAnnounce() {
             const ids = this.hostServices.map(h =>
                 h.running ? h.serviceClass : -1
@@ -120,9 +124,7 @@ namespace jacdac {
             if (this.restartCounter < 0xf) this.restartCounter++
             ids[0] =
                 this.restartCounter |
-                (roleManagerServer.running
-                    ? ControlAnnounceFlags.IsClient
-                    : 0) |
+                (this.isClient ? ControlAnnounceFlags.IsClient : 0) |
                 ControlAnnounceFlags.SupportsACK |
                 ControlAnnounceFlags.SupportsBroadcast |
                 ControlAnnounceFlags.SupportsFrames
@@ -284,7 +286,11 @@ namespace jacdac {
                             dev.services = pkt.data
                         }
 
-                        if (dev.isClient && dev.restartCounter < this.restartCounter) {
+                        if (
+                            this.isClient &&
+                            dev.isClient &&
+                            dev.restartCounter < this.restartCounter
+                        ) {
                             // the device restarted earlier than us
                             log(`device ${dev.shortId} new proxy`)
                             resetToProxy()

--- a/routing.ts
+++ b/routing.ts
@@ -36,7 +36,7 @@ namespace jacdac {
         readonly hostServices: Server[] = []
         readonly devices: Device[] = []
         private _myDevice: Device
-        private resetCount = 0
+        private restartCounter = 0
         private resetIn = 2000000 // 2s
         private autoBindCnt = 0
         private _eventCounter = 0
@@ -117,9 +117,9 @@ namespace jacdac {
             const ids = this.hostServices.map(h =>
                 h.running ? h.serviceClass : -1
             )
-            if (this.resetCount < 0xf) this.resetCount++
+            if (this.restartCounter < 0xf) this.restartCounter++
             ids[0] =
-                this.resetCount |
+                this.restartCounter |
                 (roleManagerServer.running
                     ? ControlAnnounceFlags.IsClient
                     : 0) |
@@ -264,8 +264,8 @@ namespace jacdac {
 
                 if (pkt.serviceIndex == JD_SERVICE_INDEX_CTRL) {
                     if (pkt.serviceCommand == SystemCmd.Announce) {
-                        const pktResetCount = pkt.data[0] & 0xf
-                        if (dev && dev.resetCount > pktResetCount) {
+                        const pktRestartCounter = pkt.data[0] & 0xf
+                        if (dev && dev.restartCounter > pktRestartCounter) {
                             // if the reset counter went down, it means the device reseted;
                             // treat it as new device
                             log(`device ${dev.shortId} resetted`)
@@ -284,7 +284,7 @@ namespace jacdac {
                             dev.services = pkt.data
                         }
 
-                        if (dev.isClient && dev.resetCount < this.resetCount) {
+                        if (dev.isClient && dev.restartCounter < this.restartCounter) {
                             // the device restarted earlier than us
                             log(`device ${dev.shortId} new proxy`)
                             resetToProxy()
@@ -1027,7 +1027,7 @@ namespace jacdac {
             return this.services.getNumber(NumberFormat.UInt16LE, 0)
         }
 
-        get resetCount() {
+        get restartCounter() {
             return (
                 this.announceflags & ControlAnnounceFlags.RestartCounterSteady
             )


### PR DESCRIPTION
Enter proxy mode is the reset counter is strictly less than the current reset counter.

- [x] stop using uptime
- [x] more reliable as the info is part of the announce packet