### PR TITLE
fixed endless loop with two button sensor

### DIFF
--- a/tools/uploader/twins.ts
+++ b/tools/uploader/twins.ts
@@ -389,7 +389,7 @@ namespace jacdac.twins {
                 if (this.services.find(s => s && s.id == newServ.id)) {
                     let i = 2
                     while (
-                        this.services.find(s => s.id == newServ.id + "_" + i)
+                        this.services.find(s => s && s.id == newServ.id + "_" + i)
                     )
                         i++
                     newServ.id += "_" + i


### PR DESCRIPTION
When you plug in two buttons, it causes a crash in makecode and an endless loop is created. Resolved by adding an additional check. 