### PR TITLE
reset restart counter on adding server

### DIFF
--- a/routing.ts
+++ b/routing.ts
@@ -73,6 +73,9 @@ namespace jacdac {
         addServer(server: Server) {
             server.serviceIndex = this.servers.length
             this.servers.push(server)
+            // reset restart counter to simulate a reset
+            // and force client to update service list
+            this.restartCounter = 0
         }
 
         private gcDevices() {


### PR DESCRIPTION
to simulate reset and force clients to refresh services. This case is already supported on the client side.