### PR TITLE
Add calliopemini

### DIFF
--- a/accelerometer-server/pxt.json
+++ b/accelerometer-server/pxt.json
@@ -13,7 +13,8 @@
     ],
     "supportedTargets": [
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/accelerometer-server/pxt.json
+++ b/accelerometer-server/pxt.json
@@ -13,8 +13,7 @@
     ],
     "supportedTargets": [
         "arcade",
-        "maker",
-        "calliopemini"
+        "maker"
     ],
     "preferredEditor": "tsprj"
 }

--- a/accelerometer/pxt.g.json
+++ b/accelerometer/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/accelerometer/pxt.json
+++ b/accelerometer/pxt.json
@@ -13,13 +13,14 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "testFiles": [
         "test.microbit.ts"
     ],
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/acidity/pxt.json
+++ b/acidity/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/air-pressure/pxt.json
+++ b/air-pressure/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/air-quality-index/pxt.json
+++ b/air-quality-index/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/analog-button/pxt.g.json
+++ b/analog-button/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/arcade-screen/pxt.g.json
+++ b/arcade-screen/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/arcade-sound/pxt.g.json
+++ b/arcade-sound/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/azure-iot-hub-health/pxt.g.json
+++ b/azure-iot-hub-health/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/azure-iot-hub-health/pxt.json
+++ b/azure-iot-hub-health/pxt.json
@@ -8,7 +8,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/barcode-reader/pxt.g.json
+++ b/barcode-reader/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/bit-radio/pxt.g.json
+++ b/bit-radio/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/bluetooth-transport/pxt.json
+++ b/bluetooth-transport/pxt.json
@@ -24,6 +24,7 @@
         "test.ts"
     ],
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ]
 }

--- a/braille-display/pxt.json
+++ b/braille-display/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/bridge/pxt.g.json
+++ b/bridge/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/button/pxt.g.json
+++ b/button/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/button/pxt.json
+++ b/button/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/buzzer-server/pxt.json
+++ b/buzzer-server/pxt.json
@@ -15,7 +15,8 @@
     ],
     "supportedTargets": [
         "microbit",
-        "arcade"
+        "arcade",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/buzzer/pxt.g.json
+++ b/buzzer/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/buzzer/pxt.json
+++ b/buzzer/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/capacitive-button/pxt.g.json
+++ b/capacitive-button/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/character-screen/pxt.g.json
+++ b/character-screen/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/character-screen/pxt.json
+++ b/character-screen/pxt.json
@@ -10,12 +10,13 @@
         "test.microbit.ts"
     ],
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     },
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/cloud-configuration/pxt.g.json
+++ b/cloud-configuration/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/codal-message-bus-server/pxt.json
+++ b/codal-message-bus-server/pxt.json
@@ -10,7 +10,7 @@
         "test.microbit.ts"
     ],
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     },
     "supportedTargets": [
         "microbit",

--- a/codal-message-bus-server/pxt.json
+++ b/codal-message-bus-server/pxt.json
@@ -15,7 +15,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/codal-message-bus/pxt.g.json
+++ b/codal-message-bus/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/codal-message-bus/pxt.json
+++ b/codal-message-bus/pxt.json
@@ -8,7 +8,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/color/pxt.g.json
+++ b/color/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/color/pxt.json
+++ b/color/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/compass/pxt.g.json
+++ b/compass/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/compass/pxt.json
+++ b/compass/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dashboard/pxt.g.json
+++ b/dashboard/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dc-current-measurement/pxt.json
+++ b/dc-current-measurement/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dc-voltage-measurement/pxt.json
+++ b/dc-voltage-measurement/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/device-script-condition/pxt.g.json
+++ b/device-script-condition/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/device-script-manager/pxt.g.json
+++ b/device-script-manager/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/devices/microbit/pxt.json
+++ b/devices/microbit/pxt.json
@@ -41,7 +41,8 @@
         "targetId": "microbit"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/distance/pxt.g.json
+++ b/distance/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/distance/pxt.json
+++ b/distance/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",
@@ -21,6 +22,6 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/dmx/pxt.g.json
+++ b/dmx/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dmx/pxt.json
+++ b/dmx/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dot-matrix/pxt.g.json
+++ b/dot-matrix/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dot-matrix/pxt.json
+++ b/dot-matrix/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/dual-motors/pxt.json
+++ b/dual-motors/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/e-co2/pxt.g.json
+++ b/e-co2/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/e-co2/pxt.json
+++ b/e-co2/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/flex/pxt.g.json
+++ b/flex/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/flex/pxt.json
+++ b/flex/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/gpio/pxt.g.json
+++ b/gpio/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/gyroscope/pxt.g.json
+++ b/gyroscope/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/gyroscope/pxt.json
+++ b/gyroscope/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/heart-rate/pxt.g.json
+++ b/heart-rate/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/heart-rate/pxt.json
+++ b/heart-rate/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/hid-adapter/pxt.g.json
+++ b/hid-adapter/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/hid-joystick/pxt.json
+++ b/hid-joystick/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "maker",
         "arcade",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/hid-keyboard/pxt.g.json
+++ b/hid-keyboard/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/hid-mouse/pxt.g.json
+++ b/hid-mouse/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/humidity/pxt.g.json
+++ b/humidity/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/humidity/pxt.json
+++ b/humidity/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",
@@ -20,6 +21,6 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/i2c/pxt.g.json
+++ b/i2c/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/illuminance/pxt.g.json
+++ b/illuminance/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/illuminance/pxt.json
+++ b/illuminance/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/indexed-screen/pxt.g.json
+++ b/indexed-screen/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/infrastructure/pxt.g.json
+++ b/infrastructure/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/iot-hub/pxt.g.json
+++ b/iot-hub/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/led-server/pxt.json
+++ b/led-server/pxt.json
@@ -14,12 +14,14 @@
         "test.microbit.ts"
     ],
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     },
     "supportedTargets": [
         "maker",
         "microbit",
-        "arcade"
+        "arcade",
+        "calliopemini"
+
     ],
     "preferredEditor": "tsprj"
 }

--- a/led-single/pxt.json
+++ b/led-single/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/led-strip/pxt.g.json
+++ b/led-strip/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/led-strip/pxt.json
+++ b/led-strip/pxt.json
@@ -21,10 +21,11 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/led/pxt.json
+++ b/led/pxt.json
@@ -12,10 +12,11 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     },
     "dependencies": {
         "core": "*",

--- a/light-bulb/pxt.g.json
+++ b/light-bulb/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/light-bulb/pxt.json
+++ b/light-bulb/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/light-level/pxt.g.json
+++ b/light-level/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/light-level/pxt.json
+++ b/light-level/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/magnetic-field-level/pxt.json
+++ b/magnetic-field-level/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/magnetometer/pxt.g.json
+++ b/magnetometer/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/magnetometer/pxt.json
+++ b/magnetometer/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/matrix-keypad/pxt.g.json
+++ b/matrix-keypad/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/microphone/pxt.g.json
+++ b/microphone/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/midi-output/pxt.g.json
+++ b/midi-output/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/mk.sh
+++ b/mk.sh
@@ -4,3 +4,4 @@ set -e
 makecode -u -j --mono-repo -c mkc.json
 makecode -u -j --mono-repo -c mkc-maker.json
 makecode -u -j --mono-repo -c mkc-arcade.json
+makecode -u -j --mono-repo -c mkc-calliope.json

--- a/mkc-calliope.json
+++ b/mkc-calliope.json
@@ -1,0 +1,9 @@
+{
+    "targetWebsite": "https://makecode.calliope.cc/",
+    "overrides": {
+        "testDependencies": {}
+    },
+    "include": [
+        "links.json"
+    ]
+}

--- a/model-runner/pxt.g.json
+++ b/model-runner/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/model-runner/pxt.json
+++ b/model-runner/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/motion/pxt.g.json
+++ b/motion/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/motion/pxt.json
+++ b/motion/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/motor/pxt.g.json
+++ b/motor/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/motor/pxt.json
+++ b/motor/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/multitouch/pxt.g.json
+++ b/multitouch/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/multitouch/pxt.json
+++ b/multitouch/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/planar-position/pxt.json
+++ b/planar-position/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/potentiometer/pxt.g.json
+++ b/potentiometer/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/potentiometer/pxt.json
+++ b/potentiometer/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/power-supply/pxt.g.json
+++ b/power-supply/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/pressure-button/pxt.g.json
+++ b/pressure-button/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/proto-test/pxt.g.json
+++ b/proto-test/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/proxy/pxt.g.json
+++ b/proxy/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/pulse-oximeter/pxt.g.json
+++ b/pulse-oximeter/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/pulse-oximeter/pxt.json
+++ b/pulse-oximeter/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/pxt.json
+++ b/pxt.json
@@ -69,10 +69,12 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "mbcompat.ts": "target:microbit || target:calliopemini",
+        "mbcompat.ts": "target:microbit",
+        "mbcompat.ts": "target:calliopemini",
         "nonmaker.ts": "!target:maker",
         "maker.ts": "target:maker",
-        "test.microbit.ts": "target:microbit || target:calliopemini",
+        "test.microbit.ts": "target:microbit",
+        "test.microbit.ts": "target:calliopemini",
         "hw.cpp": "!core---esp32 && !core---esp32s2",
         "hw-esp32.c": "core---esp32 || core---esp32s2"
     },

--- a/pxt.json
+++ b/pxt.json
@@ -69,12 +69,10 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "mbcompat.ts": "target:microbit",
-        "mbcompat.ts": "target:calliopemini",
+        "mbcompat.ts": "target:microbit || target:calliopemini",
         "nonmaker.ts": "!target:maker",
         "maker.ts": "target:maker",
-        "test.microbit.ts": "target:microbit",
-        "test.microbit.ts": "target:calliopemini",
+        "test.microbit.ts": "target:microbit || target:calliopemini",
         "hw.cpp": "!core---esp32 && !core---esp32s2",
         "hw-esp32.c": "core---esp32 || core---esp32s2"
     },

--- a/pxt.json
+++ b/pxt.json
@@ -69,10 +69,10 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "mbcompat.ts": "target:microbit",
+        "mbcompat.ts": "target:microbit || target:calliopemini",
         "nonmaker.ts": "!target:maker",
         "maker.ts": "target:maker",
-        "test.microbit.ts": "target:microbit",
+        "test.microbit.ts": "target:microbit || target:calliopemini",
         "hw.cpp": "!core---esp32 && !core---esp32s2",
         "hw-esp32.c": "core---esp32 || core---esp32s2"
     },
@@ -84,7 +84,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "disablesVariants": [

--- a/rain-gauge/pxt.g.json
+++ b/rain-gauge/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/rain-gauge/pxt.json
+++ b/rain-gauge/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/real-time-clock/pxt.g.json
+++ b/real-time-clock/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/real-time-clock/pxt.json
+++ b/real-time-clock/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/reflected-light/pxt.g.json
+++ b/reflected-light/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/reflected-light/pxt.json
+++ b/reflected-light/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/relay/pxt.g.json
+++ b/relay/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/relay/pxt.json
+++ b/relay/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/rng/pxt.json
+++ b/rng/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/role-manager/pxt.g.json
+++ b/role-manager/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/ros/pxt.g.json
+++ b/ros/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/rotary-encoder/pxt.g.json
+++ b/rotary-encoder/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/rotary-encoder/pxt.json
+++ b/rotary-encoder/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/rover/pxt.g.json
+++ b/rover/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sat-nav/pxt.json
+++ b/sat-nav/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sensor-aggregator/pxt.g.json
+++ b/sensor-aggregator/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sensor-aggregator/pxt.json
+++ b/sensor-aggregator/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/serial/pxt.g.json
+++ b/serial/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/servers/pxt.json
+++ b/servers/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/servo-server/pxt.json
+++ b/servo-server/pxt.json
@@ -14,11 +14,12 @@
         "test.microbit.ts"
     ],
     "fileDependencies": {
-        "server.microbit.ts": "target:microbit",
-        "test.microbit.ts": "target:microbit"
+        "server.microbit.ts": "target:microbit || target:calliopemini",
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/servo/pxt.g.json
+++ b/servo/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/servo/pxt.json
+++ b/servo/pxt.json
@@ -17,10 +17,11 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/settings/pxt.g.json
+++ b/settings/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/seven-segment-display/pxt.json
+++ b/seven-segment-display/pxt.json
@@ -12,13 +12,14 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac"
     },
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/soil-moisture/pxt.g.json
+++ b/soil-moisture/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/soil-moisture/pxt.json
+++ b/soil-moisture/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/solenoid/pxt.g.json
+++ b/solenoid/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/solenoid/pxt.json
+++ b/solenoid/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sound-level/pxt.g.json
+++ b/sound-level/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sound-level/pxt.json
+++ b/sound-level/pxt.json
@@ -13,7 +13,8 @@
     "supportedTargets": [
         "arcade",
         "maker",
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj"
 }

--- a/sound-player/pxt.g.json
+++ b/sound-player/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sound-recorder-with-playback/pxt.g.json
+++ b/sound-recorder-with-playback/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/sound-spectrum/pxt.g.json
+++ b/sound-spectrum/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/speech-synthesis/pxt.g.json
+++ b/speech-synthesis/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/speech-synthesis/pxt.json
+++ b/speech-synthesis/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/switch-button/pxt.g.json
+++ b/switch-button/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/switch/pxt.json
+++ b/switch/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/tcp/pxt.g.json
+++ b/tcp/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/tcp/pxt.json
+++ b/tcp/pxt.json
@@ -8,7 +8,8 @@
     ],
     "supportedTargets": [
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/temperature/pxt.json
+++ b/temperature/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",
@@ -20,6 +21,6 @@
     ],
     "testDependencies": {},
     "fileDependencies": {
-        "test.microbit.ts": "target:microbit"
+        "test.microbit.ts": "target:microbit || target:calliopemini"
     }
 }

--- a/timeseries-aggregator/pxt.g.json
+++ b/timeseries-aggregator/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/tools/farm-beats/pxt.json
+++ b/tools/farm-beats/pxt.json
@@ -22,7 +22,8 @@
         "targetId": "microbit"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "version": "1.9.19"

--- a/tools/microbit-jukebox/pxt.json
+++ b/tools/microbit-jukebox/pxt.json
@@ -59,7 +59,8 @@
         "targetId": "microbit"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "disableTargetTemplateFiles": true,

--- a/tools/microbit-microcode-servers/pxt.json
+++ b/tools/microbit-microcode-servers/pxt.json
@@ -18,7 +18,8 @@
         "targetId": "microbit"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "disableTargetTemplateFiles": true,

--- a/tools/microbit-oob/pxt.json
+++ b/tools/microbit-oob/pxt.json
@@ -30,7 +30,8 @@
         "targetId": "microbit"
     },
     "supportedTargets": [
-        "microbit"
+        "microbit",
+        "calliopemini"
     ],
     "preferredEditor": "tsprj",
     "disableTargetTemplateFiles": true,

--- a/traffic-light/pxt.json
+++ b/traffic-light/pxt.json
@@ -9,7 +9,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/tvoc/pxt.g.json
+++ b/tvoc/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/tvoc/pxt.json
+++ b/tvoc/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/unique-brain/pxt.g.json
+++ b/unique-brain/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/usb-bridge/pxt.g.json
+++ b/usb-bridge/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/uv-index/pxt.g.json
+++ b/uv-index/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/uv-index/pxt.json
+++ b/uv-index/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/verified-telemetry/pxt.g.json
+++ b/verified-telemetry/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/vibration-motor/pxt.g.json
+++ b/vibration-motor/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/vibration-motor/pxt.json
+++ b/vibration-motor/pxt.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/water-level/pxt.g.json
+++ b/water-level/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/water-level/pxt.json
+++ b/water-level/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/weight-scale/pxt.g.json
+++ b/weight-scale/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/weight-scale/pxt.json
+++ b/weight-scale/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wifi/pxt.g.json
+++ b/wifi/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wind-direction/pxt.g.json
+++ b/wind-direction/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wind-direction/pxt.json
+++ b/wind-direction/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wind-speed/pxt.g.json
+++ b/wind-speed/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wind-speed/pxt.json
+++ b/wind-speed/pxt.json
@@ -10,7 +10,8 @@
     "supportedTargets": [
         "arcade",
         "microbit",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",

--- a/wssk/pxt.g.json
+++ b/wssk/pxt.g.json
@@ -12,7 +12,8 @@
     "supportedTargets": [
         "microbit",
         "arcade",
-        "maker"
+        "maker",
+        "calliopemini"
     ],
     "dependencies": {
         "core": "*",


### PR DESCRIPTION
This PR aims to add the Calliope mini 3 to support jacdac

I am able to load our fork into [makecode.calliope.cc/alpha](https://makecode.calliope.cc/alpha), but when I press `add Blocks` the additional extensions are loaded from microsoft/pxt-jacdac which raises errors. So supporting the Calliope mini 3 in this repository would be great.

![image](https://github.com/microsoft/pxt-jacdac/assets/3764089/80344cf1-ad62-4dfe-98bb-5bab4ddb9528)
