### PR TITLE
Fix optional config settings

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -112,12 +112,12 @@
                 "bluetooth": {
                     "enabled": 0
                 }
-            },
-            "optionalConfig": {
-                "microbit-dal": {
-                    "bluetooth": {
-                        "enabled": 0
-                    }
+            }
+        },
+        "optionalConfig": {
+            "microbit-dal": {
+                "bluetooth": {
+                    "enabled": 0
                 }
             }
         }


### PR DESCRIPTION
Fixes the nesting of optional config.

Optional config is required to make sure switches in the project settings are reflecting the state of Bluetooth.